### PR TITLE
Allow ignoring elements

### DIFF
--- a/make-tree.js
+++ b/make-tree.js
@@ -60,7 +60,13 @@ function makeHeadingId(text) {
 function makeTreeData(elements) {
 	var ids = {};
 	var map = [].map;
-
+	elements = elements.filter(function(element) {
+		// for testing
+		if (element.attributes) {
+			return !element.attributes['data-skip'];
+		}
+		return true;
+	});
 	return map.call(elements, function(element) {
 		var text = element.textContent;
 		var id = element.id || makeHeadingId(text);

--- a/make-tree.js
+++ b/make-tree.js
@@ -60,13 +60,16 @@ function makeHeadingId(text) {
 function makeTreeData(elements) {
 	var ids = {};
 	var map = [].map;
+
+	// Get elements without [data-skip] attribute only
 	elements = elements.filter(function(element) {
-		// for testing
+		// check if element has attributes (for testing)
 		if (element.attributes) {
 			return !element.attributes['data-skip'];
 		}
 		return true;
 	});
+	
 	return map.call(elements, function(element) {
 		var text = element.textContent;
 		var id = element.id || makeHeadingId(text);

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "jshint": "^2.9.4",
     "steal": "^0.16.41",
     "steal-mocha": "0.0.3",
-    "testee": "^0.3.0-pre.2"
+    "testee": "^0.9.1"
   }
 }

--- a/test/make-tree-test.js
+++ b/test/make-tree-test.js
@@ -56,4 +56,16 @@ describe("makeTree", function() {
 			{ id: "writing-modules", level: 2, text: "Writing Modules", children: [] }
 		]);
 	});
+
+	it("allows ignoring elements with data-skip attribute", function() {
+		var elements = [
+			{ tagName: "h2", textContent: "new MyType", attributes: {} },
+			{ tagName: "h3", textContent: "Parameters", attributes: { 'data-skip': {} } },
+			{ tagName: "h2", textContent: "Configure", attributes: {} }
+		];
+		assert.deepEqual(makeTree(elements), [
+			{id: "new-mytype", level: 2, text: "new MyType", children: []},
+			{ id: "configure", level: 2, text: "Configure", children: [] }
+		]);
+	});
 });


### PR DESCRIPTION
Ignore elements with `data-skip` attribute in `makeTree` function, for example:
`<h3 class="parameters-title" data-skip>Parameters</h3>`
This element will not be rendered in the TOC.

Needed for https://github.com/canjs/bit-docs-html-canjs/issues/455 which has PR https://github.com/canjs/bit-docs-html-canjs/pull/539

### Before
<img width="311" alt="toc-before" src="https://user-images.githubusercontent.com/109013/59233502-9fb6c000-8be0-11e9-8a4f-dca7fc7a210a.png">

### After
<img width="325" alt="toc-after" src="https://user-images.githubusercontent.com/109013/59233511-a9402800-8be0-11e9-83f7-5691238043bc.png">

